### PR TITLE
feature/from-the-div-tag-make-textarea

### DIFF
--- a/From-the-div-tag-make-texarea/test.js
+++ b/From-the-div-tag-make-texarea/test.js
@@ -1,0 +1,26 @@
+const wrap = document.querySelector(".wrap");
+
+wrap.addEventListener("click", () => {
+  wrap.style.display = "none";
+
+  const textAreaElement = document.createElement("textarea");
+  textAreaElement.classList.add("wrap");
+  textAreaElement.value = wrap.innerHTML;
+  wrap.after(textAreaElement);
+
+  textAreaElement.focus();
+
+  textAreaElement.addEventListener("blur", () => {
+    wrap.innerHTML = textAreaElement.value;
+
+    textAreaElement.remove();
+
+    wrap.style.display = "";
+  });
+
+  textAreaElement.addEventListener("keydown", (event) => {
+    if (event.code == "Enter") {
+      textAreaElement.blur();
+    }
+  });
+});


### PR DESCRIPTION
We made a div, when you click on it you get a textarea, you fill in what you need, but when you click on another area, the text stays.

![q4](https://github.com/Konmly/Tasks/assets/62384781/0540cd7c-1be5-4c1f-97e9-c100ad7d7ed8)
![q3](https://github.com/Konmly/Tasks/assets/62384781/eb1b8fa7-f16a-464b-9187-fc083754d610)
